### PR TITLE
Adding depreciation warning to README for dropping Python 3.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ DataFrame, and XML.
 
 Conversions can be done on either a single file, an entire directory, or a batch of specified files.
 
+### Depreciation Warning
+Support for Python 3.6 will be dropped with the next release (Python 3.7.1 will be the minimum supported version) so that Pandas 1.2.0 can be supported.
+
 ## Install
 `pip install sas7bdat_converter`
 


### PR DESCRIPTION
With the release of Pandas 1.2.0 the minimum version of Python is 3.7.1 so this is a warning that the next release will no longer support Python 3.6