### PR TITLE
Renaming master to main

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -2,16 +2,13 @@ name: Linting
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
-
+    - main
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,13 +1,11 @@
 name: Tests
-
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
     branches:
-    - master
-
+    - main
 jobs:
   Testing:
     strategy:


### PR DESCRIPTION
The default branch was renamed from master to main so updating the CI files to point to the new branch.